### PR TITLE
Update alfresco-search.yaml

### DIFF
--- a/docs/openapi/alfresco-search.yaml
+++ b/docs/openapi/alfresco-search.yaml
@@ -700,7 +700,7 @@ definitions:
       A template called "WOOF" defined as "%(cm:name cm:title)" allows
       WOOF:example
       to generate
-      cm:name:example cm:name:example
+      cm:name:example cm:title:example
     type: array
     items:
       type: object


### PR DESCRIPTION
typo in example: template should generate "cm:name:example cm:title:example"